### PR TITLE
Transient for just 2 assoc! calls is slower

### DIFF
--- a/dev/benchmarks.clj
+++ b/dev/benchmarks.clj
@@ -1,24 +1,7 @@
 (ns benchmarks
-  (:use jordanlewis.data.union-find)
+  (:use jordanlewis.data.union-find
+        dev-utils)
   (:require [criterium.core :refer [bench quick-bench]]))
-
-(defn make-stars [stars points]
-  (for [a (range stars)
-        b (range points)
-        :let [b (+ stars (* a points) b)]]
-    [a b (str b)]))
-
-(defn partition-graph [uf stars points -conj -union]
-  (reduce
-    (fn [uf [a b c]]
-      (-> uf
-          (-conj a)
-          (-conj b)
-          (-conj c)
-          (-union a b)
-          (-union b c)))
-    uf
-    (make-stars stars points)))
 
 (comment
 

--- a/src/jordanlewis/data/union_find.clj
+++ b/src/jordanlewis/data/union_find.clj
@@ -80,7 +80,7 @@ sets that x and y belong to unioned."))
   clojure.lang.Seqable
   ;; seq returns each of the canonical elements, not all of the elements
   (seq [this]
-    (map first (filter (comp nil? parent val) elt-map)))
+    (map key (filter (comp nil? parent val) elt-map)))
 
   clojure.lang.IPersistentCollection
   ;; cons adds the input to a new singleton set
@@ -157,11 +157,9 @@ sets that x and y belong to unioned."))
                                 (update-in elt-map [y-root] #(->UFNode (value %) (rank %) x-root))
                                 num-sets _meta)
             :else (PersistentDSF.
-                    (-> elt-map
-                        (transient)
-                        (assoc! y-root (->UFNode (value y-node) (rank y-node) x-root))
-                        (assoc! x-root (->UFNode (value x-node) (inc x-rank) (parent x-node)))
-                        (persistent!))
+                    (assoc elt-map
+                           y-root (->UFNode (value y-node) (rank y-node) x-root)
+                           x-root (->UFNode (value x-node) (inc x-rank) (parent x-node)))
                     num-sets _meta)))))
 
 (deftype TransientDSF [^:unsynchronized-mutable elt-map


### PR DESCRIPTION
This is a very minor improvement but since I identified it, thought I might as well include it.