### PR TITLE
Added deps.edn and download coordinates for current version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .lein-failures
 .lein-deps-sum
 .nrepl-port
+.cpcache

--- a/README.md
+++ b/README.md
@@ -3,32 +3,44 @@
 A Clojure implementation of persistent disjoint-set forests using Tarjan's
 union-find algorithm.
 
-    com.github.pangloss/data.union-find {:git/tag "0.1.2" :sha "0e8a06f"}
+    com.github.jordanlewis/data.union-find {:git/tag "1.0.0" :sha "0e8a06f"}
+    
+This is not currently released on Clojars. If someone needs that, please put in
+a ticket and it can be done.
+
+This library is stable and I do not currently anticipate any changes.
 
 ## Usage
 
 Make a new union-find data structure containing its arguments as singleton sets:
 
-    user=> (use 'jordanlewis.data.union-find)
-    user=> (def uf (union-find 1 2 3 4 5))
-    user=> uf
-    {5 [5], 4 [4], 3 [3], 2 [2], 1 [1]}
+    (use 'jordanlewis.data.union-find)
+    (def uf (union-find 1 2 3 4 5))
+    uf
+    ;; => {5 [5], 4 [4], 3 [3], 2 [2], 1 [1]}
 
 Add a new element as a singleton set with conj or cons:
 
-    user=> (conj uf 8)
-    {8 [8], 5 [5], 4 [4], 2 [3 2], 1 [1]}
+    (conj uf 8)
+    ;; => {8 [8], 5 [5], 4 [4], 2 [3 2], 1 [1]}
 
 Union two sets:
 
-    user=> (def uf (union uf 2 3))
-    user=> uf
-    {5 [5], 4 [4], 2 [3 2], 1 [1]}
+    (def uf (union uf 2 3))
+    uf
+    ;; => {5 [5], 4 [4], 2 [3 2], 1 [1]}
 
 Look up the canonical element for an element:
 
-    user=> (get-canonical uf 3)
-    [{5 [5], 4 [4], 2 [3 2], 1 [1]} 2]
+    (get-canonical uf 3)
+    ;; => [{5 [5], 4 [4], 2 [3 2], 1 [1]} 2]
+    
+Union find also supports being used as a transient editable collection, which
+can improve performance in some scenarios:
+
+    (-> (transient uf)
+        (union! 2 5)
+        persistent!)
 
 Getting the canonical element of a set can change the internals of the data structure,
 due to an optimization called path compression. Therefore, get-canonical returns two
@@ -37,32 +49,28 @@ objects: the updated data structure, and the requested canonical element.
 Getting the count of a union-find data structure returns the number of connected
 components, not the number of elements. count is a constant-time operation.
 
-    user=> (count uf)
-    4 ;; 4 connected components, but 5 elements
+    (count uf) ;; => 4
+    ;; 4 connected components, but 5 elements
 
 Treating a union-find data structure as a seq similiarly returns only the
 canonical elements of the data structure, not all of the elements:
 
-    user=> (seq uf)
-    (5 4 2 1) ;; doesn't include 3, which is a non-canonical element
+    (seq uf) ;; => (5 4 2 1) 
+    ;; doesn't include 3, which is a non-canonical element
 
 union-find also implements ILookup and IFn as canonical element lookups, so you
 can use get on it or apply it to an element like you would with a vector or a
 map. Using it this way doesn't perform the path compression optimization, and
 just returns the canonical element.
 
-    user=> (uf 3)
-    2
-    user=> (get uf 3)
-    2
-    user=> (uf 10)
-    nil
-    user=> (uf 10 :not-found)
-    :not-found
+    (uf 3) ;; => 2
+    (get uf 3) ;; => 2
+    (uf 10) ;; => nil
+    (uf 10 :not-found) ;; => :not-found
 
 
 ## License
 
-Copyright © 2012 Jordan Lewis
+Copyright © 2012-2022 Jordan Lewis and Darrick Wiebe
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 A Clojure implementation of persistent disjoint-set forests using Tarjan's
 union-find algorithm.
 
-Available in Leiningen via [Clojars](https://clojars.org/org.jordanlewis/data.union-find):
-
-    [org.jordanlewis/data.union-find "0.1.0"]
+    com.github.pangloss/data.union-find {:git/tag "0.1.2" :sha "0e8a06f"}
 
 ## Usage
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths   ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :aliases
+ {:test
+  {:extra-paths ["dev" "test"]
+   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]}
+  :dev
+  {:extra-paths ["dev"]
+   :extra-deps {criterium/criterium {:mvn/version "0.4.6"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
             :url "http://github.com/jordanlewis/data.union-find"
             :license {:name "Eclipse Public License"
                       :url "http://www.eclipse.org/legal/epl-v10.html"}
-            :dependencies [[org.clojure/clojure "1.6.0"]]
+            :dependencies [[org.clojure/clojure "1.11.1"]]
 
             :profiles
             {:dev {:source-paths      ["src" "dev"]
-                   :dependencies [[criterium "0.4.3"]]}})
+                   :dependencies [[criterium "0.4.6"]]}})


### PR DESCRIPTION
Last time I needed this lib for a genetics project. Now I need it again for writing a compiler! Anyway, somehow the v0.1.1 release has gone missing.

Just so I can move forward, I created a deps.edn and tagged a git-based release from my fork. That works for me but I thought you may want to cut a new release or at least update the coordinates to point to your repo.

I updated the couple dependencies to latest while I was at it, too. Easy since no changes were required.

Cheers!
Darrick